### PR TITLE
Migrate to the NamedGraphs v0.14 interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ Graphs = "1.8.0"
 ITensors = "0.9"
 KrylovKit = "0.10.2"
 LinearAlgebra = "1.10"
-NamedGraphs = "0.13"
+NamedGraphs = "0.14"
 OMEinsumContractionOrders = "1.3"
 SimpleGraphAlgorithms = "0.6.0"
 SimpleGraphConverter = "0.1.0"
@@ -36,6 +36,10 @@ Statistics = "1.10"
 StatsBase = "0.34.4"
 TypeParameterAccessors = "0.3.10, 0.4"
 julia = "1.10"
+
+[sources.NamedGraphs]
+url = "https://github.com/ITensor/NamedGraphs.jl"
+rev = "main"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -37,10 +37,6 @@ StatsBase = "0.34.4"
 TypeParameterAccessors = "0.3.10, 0.4"
 julia = "1.10"
 
-[sources.NamedGraphs]
-url = "https://github.com/ITensor/NamedGraphs.jl"
-rev = "main"
-
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/MessagePassing/abstractbeliefpropagationcache.jl
+++ b/src/MessagePassing/abstractbeliefpropagationcache.jl
@@ -70,9 +70,6 @@ for f in [
         :(NamedGraphs.edgetype),
         :(NamedGraphs.vertices),
         :(NamedGraphs.edges),
-        :(NamedGraphs.position_graph),
-        :(NamedGraphs.ordered_vertices),
-        :(NamedGraphs.vertex_positions),
         :(NamedGraphs.steiner_tree),
         :(NamedGraphs.is_tree),
     ]
@@ -82,6 +79,10 @@ for f in [
         end
     end
 end
+
+NamedGraphs.encoded_vertex(bp_cache::AbstractBeliefPropagationCache, vertex) = NamedGraphs.encoded_vertex(graph(bp_cache), vertex)
+NamedGraphs.decoded_vertex(bp_cache::AbstractBeliefPropagationCache, code::Integer) = NamedGraphs.decoded_vertex(graph(bp_cache), code)
+NamedGraphs.encoded_graph(bp_cache::AbstractBeliefPropagationCache) = NamedGraphs.encoded_graph(graph(bp_cache))
 
 #Functions derived from the interface
 function deletemessage!(bp_cache::AbstractBeliefPropagationCache, e::AbstractEdge)
@@ -123,7 +124,7 @@ function setmessages!(bp_cache::AbstractBeliefPropagationCache, edges, messages)
 end
 
 function deletemessages!(
-        bp_cache::AbstractBeliefPropagationCache, edges::Vector{<:AbstractEdge} = edges(bp_cache)
+        bp_cache::AbstractBeliefPropagationCache, edges::Vector{<:AbstractEdge} = collect(edges(bp_cache))
     )
     for e in edges
         deletemessage!(bp_cache, e)
@@ -150,7 +151,7 @@ end
 function incoming_messages(
         bp_cache::AbstractBeliefPropagationCache, vertices::Vector{<:Any}; ignore_edges = []
     )
-    b_edges = NamedGraphs.GraphsExtensions.boundary_edges(bp_cache, vertices; dir = :in)
+    b_edges = NamedGraphs.boundary_edges(bp_cache, vertices; dir = :in)
     b_edges = !isempty(ignore_edges) ? setdiff(b_edges, ignore_edges) : b_edges
     return messages(bp_cache, b_edges)
 end
@@ -308,7 +309,7 @@ function rescale_messages!(bp_cache::AbstractBeliefPropagationCache, edge::Abstr
 end
 
 function rescale_messages!(bp_cache::AbstractBeliefPropagationCache)
-    return rescale_messages!(bp_cache, edges(bp_cache))
+    return rescale_messages!(bp_cache, collect(edges(bp_cache)))
 end
 
 function rescale_vertices!(bpc::AbstractBeliefPropagationCache; kwargs...)

--- a/src/MessagePassing/beliefpropagationcache.jl
+++ b/src/MessagePassing/beliefpropagationcache.jl
@@ -1,6 +1,6 @@
 using Dictionaries: Dictionary, set!, delete!
 using Graphs: AbstractGraph, is_tree, connected_components
-using NamedGraphs.GraphsExtensions: default_root_vertex, forest_cover, post_order_dfs_edges, forest_cover_edge_sequence, boundary_edges, leaf_vertices, a_star
+using NamedGraphs: post_order_dfs_edges, forest_cover_edge_sequence, boundary_edges, leaf_vertices, a_star
 using ITensors: dim, ITensor, delta, Algorithm
 using ITensors.NDTensors: scalartype
 using LinearAlgebra: normalize

--- a/src/MessagePassing/boundarympscache.jl
+++ b/src/MessagePassing/boundarympscache.jl
@@ -1,7 +1,6 @@
 using NamedGraphs.PartitionedGraphs: PartitionedGraph, quotient_graph, quotientvertices, 
     QuotientEdge, quotientedges, quotientedge, QuotientVertex, unpartitioned_graph, QuotientEdges
-using NamedGraphs: add_edges!, NamedDiGraph
-using NamedGraphs.GraphsExtensions: directed_graph, undirected_graph, forest_cover_edge_sequence, all_edges
+using NamedGraphs: add_edges!, forest_cover_edge_sequence, all_edges
 using SplitApplyCombine: group
 
 #TODO: Make this show() nicely.
@@ -171,7 +170,7 @@ function BoundaryMPSCache(
     return bmps_cache
 end
 
-all_quotientedges(graph) = QuotientEdges(all_edges(quotient_graph(graph)))
+all_quotientedges(graph) = QuotientEdges(collect(all_edges(quotient_graph(graph))))
 
 #Initialise all the interpartition message tensors
 function set_interpartition_messages!(
@@ -216,7 +215,7 @@ end
 
 function partition_graph(bmps_cache::BoundaryMPSCache, partition::QuotientVertex)
     vs = vertices(supergraph(bmps_cache), partition)
-    es = filter(e -> src(e) ∈ vs && dst(e) ∈ vs, edges(supergraph(bmps_cache)))
+    es = filter(e -> src(e) ∈ vs && dst(e) ∈ vs, collect(edges(supergraph(bmps_cache))))
     g = NamedGraph(vs)
     add_edges!(g, es)
     return g
@@ -517,7 +516,7 @@ end
 
 function delete_partition_messages!(bmps_cache::BoundaryMPSCache, partition::QuotientVertex)
     g = partition_graph(bmps_cache, partition)
-    es = edges(g)
+    es = collect(edges(g))
     es = vcat(es, reverse.(es))
     return deletemessages!(bmps_cache, filter(e -> e ∈ keys(messages(bmps_cache)), es))
 end

--- a/src/MessagePassing/loopcorrection.jl
+++ b/src/MessagePassing/loopcorrection.jl
@@ -1,4 +1,4 @@
-using NamedGraphs.GraphsExtensions: boundary_edges
+using NamedGraphs: boundary_edges
 
 function loopcorrected_partitionfunction(
         bp_cache::BeliefPropagationCache,
@@ -61,14 +61,14 @@ function sim_edgeinduced_subgraph(bpc::BeliefPropagationCache, eg)
 end
 
 #Get the all edges incident to the region specified by the vector of edges passed
-function NamedGraphs.GraphsExtensions.boundary_edges(
+function NamedGraphs.boundary_edges(
         bpc::BeliefPropagationCache,
         es::Vector{<:NamedEdge},
     )
     vs = unique(vcat(src.(es), dst.(es)))
     bpes = NamedEdge[]
     for v in vs
-        incoming_es = NamedGraphs.GraphsExtensions.boundary_edges(bpc, [v]; dir = :in)
+        incoming_es = NamedGraphs.boundary_edges(bpc, [v]; dir = :in)
         incoming_es = filter(e -> e ∉ es && reverse(e) ∉ es, incoming_es)
         append!(bpes, incoming_es)
     end

--- a/src/TensorNetworks/abstracttensornetwork.jl
+++ b/src/TensorNetworks/abstracttensornetwork.jl
@@ -13,9 +13,9 @@ add_tensor!(tn::AbstractTensorNetwork, tensor::ITensor, v) = not_implemented()
 
 Graphs.is_directed(::Type{<:AbstractTensorNetwork}) = false
 
-NamedGraphs.vertex_positions(tn::AbstractTensorNetwork) = NamedGraphs.vertex_positions(graph(tn))
-NamedGraphs.ordered_vertices(tn::AbstractTensorNetwork) = NamedGraphs.ordered_vertices(graph(tn))
-NamedGraphs.position_graph(tn::AbstractTensorNetwork) = NamedGraphs.position_graph(graph(tn))
+NamedGraphs.encoded_vertex(tn::AbstractTensorNetwork, vertex) = NamedGraphs.encoded_vertex(graph(tn), vertex)
+NamedGraphs.decoded_vertex(tn::AbstractTensorNetwork, code::Integer) = NamedGraphs.decoded_vertex(graph(tn), code)
+NamedGraphs.encoded_graph(tn::AbstractTensorNetwork) = NamedGraphs.encoded_graph(graph(tn))
 NamedGraphs.vertices(tn::AbstractTensorNetwork) = NamedGraphs.vertices(graph(tn))
 NamedGraphs.edges(tn::AbstractTensorNetwork) = NamedGraphs.edges(graph(tn))
 NamedGraphs.edgetype(tn::AbstractTensorNetwork) = NamedGraphs.edgetype(graph(tn))
@@ -133,7 +133,7 @@ function add(tn1::AbstractTensorNetwork, tn2::AbstractTensorNetwork)
         @assert tn1 isa TensorNetwork && tn2 isa TensorNetwork
     end
 
-    es = edges(tn1)
+    es = collect(edges(tn1))
     tn12 = copy(tn1)
     new_edge_indices = Dict(
         zip(

--- a/src/TensorNetworks/tensornetwork.jl
+++ b/src/TensorNetworks/tensornetwork.jl
@@ -1,8 +1,7 @@
 using Dictionaries: Dictionary
 using Graphs: Graphs
 using ITensors: ITensors, ITensor
-using NamedGraphs: NamedGraphs, add_edge!, incident_edges
-using NamedGraphs.GraphsExtensions: rem_edges!
+using NamedGraphs: NamedGraphs, add_edge!, incident_edges, rem_edges!
 using Adapt
 
 #TODO: Make this show() nicely.

--- a/src/TensorNetworks/tensornetworkstate_constructors.jl
+++ b/src/TensorNetworks/tensornetworkstate_constructors.jl
@@ -61,7 +61,7 @@ function toriccode_groundstate(n::Int, s::Dictionary = siteinds("S=1/2", named_g
     g = named_grid((n,n); periodic = true)
     vs = collect(vertices(g))
     tensors = Dictionary{vertextype(g), ITensor}()
-    es=  edges(g)
+    es=  collect(edges(g))
     e_dict = Dictionary(es, [Index(2) for e in edges(g)])
     e_dict = merge(e_dict, Dictionary(reverse.(es), collect(values(e_dict))))
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -13,14 +13,12 @@ using NamedGraphs:
     AbstractNamedGraph,
     AbstractGraph,
     AbstractEdge,
-    position_graph,
     rename_vertices,
     edges,
     vertextype,
     add_vertex!,
     neighbors,
-    leafless_edge_induced_subgraphs
-using NamedGraphs.GraphsExtensions:
+    leafless_edge_induced_subgraphs,
     src,
     dst,
     subgraph,
@@ -29,7 +27,6 @@ using NamedGraphs.GraphsExtensions:
     add_edge,
     a_star,
     add_edge!,
-    edgetype,
     leaf_vertices,
     post_order_dfs_edges,
     add_vertex,
@@ -38,7 +35,7 @@ using NamedGraphs.GraphsExtensions:
     add_edges,
     rem_vertex!
 
-using NamedGraphs.NamedGraphGenerators: named_grid, named_hexagonal_lattice_graph, named_comb_tree, named_path_graph
+using NamedGraphs: named_grid, named_hexagonal_lattice_graph, named_comb_tree, named_path_graph
 
 using ITensors: ITensors
 using ITensors: Index, ITensor, hasqns, noncommonind, combinedind, combiner, replaceinds, sim, onehot, delta, plev, dense, unioninds, uniqueinds, commonind, commoninds, replaceind, datatype, inds, dag, noprime, factorize_svd, prime, hascommoninds, map_diag!, @Algorithm_str, scalar, @OpName_str, @SiteType_str, denseblocks, tags, op, apply, contract, inner


### PR DESCRIPTION
## Summary

NamedGraphs v0.14 removed the submodules and the position-graph interface this package imported, so it no longer loads. The type changes need handling too: `edges` is now lazy, and the encode and decode functions take two arguments where the position-graph ones took one.
